### PR TITLE
Fix D2 Realm multiple logons with same account

### DIFF
--- a/src/main/scala/com/init6/connection/binary/BinaryMessageHandler.scala
+++ b/src/main/scala/com/init6/connection/binary/BinaryMessageHandler.scala
@@ -188,7 +188,7 @@ class BinaryMessageHandler(connectionInfo: ConnectionInfo) extends Init6KeepAliv
 
   when(ExpectingRealmCreateCookieFromDAO) {
     case Event(RealmCreateCookieAck(cookie), _) =>
-      send(SidLogonRealmEx(cookie, username))
+      send(SidLogonRealmEx(cookie, oldUsername))
       goto(ExpectingSidEnterChat)
   }
 


### PR DESCRIPTION
# Fix D2 Realm multiple logons with same account
Sending Account Name and not Unique Name to D2 External Servers so multiple characters can logon with the same battle.net account.
![2 d2 accounts init6](https://github.com/user-attachments/assets/a2791b33-d6cd-4369-8e80-77556c8c5022)
