### PR TITLE
Set IP Ban limit back to Config value

### DIFF
--- a/src/main/scala/com/init6/connection/IpLimitActor.scala
+++ b/src/main/scala/com/init6/connection/IpLimitActor.scala
@@ -38,7 +38,7 @@ class IpLimitActor(limit: Int) extends Init6RemotingActor {
       getAcceptingUptime.toSeconds >= Config().AntiFlood.ReconnectLimit.ignoreAtStartFor) {
       val totalCount = ipTotalCount.getOrElse(addressInt, 0) + 1
       ipTotalCount.update(addressInt, totalCount)
-      totalCount <= 1000
+      totalCount <= Config().AntiFlood.ReconnectLimit.times
     } else {
       log.info("NOT ENABLED")
       true


### PR DESCRIPTION
# Changed Connection Limit back to Config
Changed IP connection limit back to config under reconnect-limit and using value times. Will IP Ban if you reach this reconnect limit instead of hard-coded.
![ip limit is config value](https://github.com/user-attachments/assets/20960bb2-4f1f-41ea-a821-f31ae92414d1)
