### PR TITLE
Diablo II multi-realm support

### DIFF
--- a/src/main/resources/init6.conf
+++ b/src/main/resources/init6.conf
@@ -43,7 +43,7 @@ init6 {
 
       enabled = false
 
-      channels = [ "init6", "init 6", "the void" ]
+      channels = [ "init6", "init 6", "the void", "Diablo II" ]
     }
   }
 
@@ -72,7 +72,7 @@ init6 {
     min-length = 2
     max-length = 15
 
-    enable-multiple = false
+    enable-multiple = true
 
     enable-ip-whitelist = false
     ip-whitelist = []
@@ -80,10 +80,13 @@ init6 {
 
   realm {
 
-    name = "Sanctuary"
-    enabled = true
-    port = 4000
-    ip_address = "127.0.0.1"
+    enabled = false
+    # Name@IP:PORT    Ensure Realm names are the same as what is set in D2CS to prevent issues
+    realms = [
+    #"Sanctuary@192.168.1.7:6113"
+    #"Sanctuary2@192.168.1.55:6113"
+    ]
+
   }
 
   anti-flood {
@@ -105,11 +108,11 @@ init6 {
     ipban-time = 120
 
     reconnect-limit {
-      enabled = true
+      enabled = false
 
       ignore-at-start-for = 45
 
-      times = 20
+      times = 1000
       in-period = 10
       ipban-time = 600
     }

--- a/src/main/scala/com/init6/Config.scala
+++ b/src/main/scala/com/init6/Config.scala
@@ -1,7 +1,8 @@
 package com.init6
 
-import java.io.File
+import com.init6.Config.getAllRealmInfo
 
+import java.io.File
 import com.init6.coders.commands.Command
 import com.typesafe.config.ConfigFactory
 
@@ -39,6 +40,21 @@ object Config {
       ConfigFactory.load(filePath)
     }
   }
+
+  def getAllRealmInfo(realms: Array[String]): List[(String, String, Int)] = {
+    realms.flatMap { realmInfo =>
+      realmInfo.split("@") match {
+        case Array(realmName, address) =>
+          address.split(":") match {
+            case Array(ip, port) if port.forall(_.isDigit) => Some((realmName, ip, port.toInt))
+            case Array(ip) => Some((realmName, ip, 6113)) // Default port if missing
+            case _ => None
+          }
+        case _ => None
+      }
+    }.toList
+  }
+
 }
 
 sealed class Config(filePath: String) {
@@ -120,8 +136,9 @@ sealed class Config(filePath: String) {
 
   object Realm {
     private val p = root.getConfig("realm")
-
-    val ipAddress = p.getString("ip_address")
+    //Get description?
+    val realmList = p.getStringList("realms").asScala.toArray
+    val realms = getAllRealmInfo(realmList)
   }
 
   object AntiFlood {

--- a/src/main/scala/com/init6/Constants.scala
+++ b/src/main/scala/com/init6/Constants.scala
@@ -34,6 +34,7 @@ object Constants {
   val CHANNELS_DISPATCHER = "channels-dispatcher"
   val USERS_DISPATCHER = "users-dispatcher"
   val SERVER_REGISTRY_DISPATCHER = "server-registry-dispatcher"
+  val D2CS_REALMS_PATH = "Realms"
 
   val WILL_DROP_IN = (serverIp: String, time: Long) => s"$serverIp will drop within 1 minute!"
 

--- a/src/main/scala/com/init6/Init6.scala
+++ b/src/main/scala/com/init6/Init6.scala
@@ -1,9 +1,9 @@
 package com.init6
 
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorRef, PoisonPill}
 import com.init6.channels.ChannelsActor
+import com.init6.connection.d2cs.D2CSActor
 import com.init6.connection.websocket.WebSocketConnectionHandler
 import com.init6.connection.{ConnectionHandler, IpLimitActor}
 import com.init6.db.{DAO, DAOActor}
@@ -27,6 +27,7 @@ object Init6 extends App with Init6Component {
   ChannelsActor()
   TopCommandActor()
   RankingActor()
+  D2CSActor()
 //  ServerAnnouncementActor(args(0).toLong)
 
   val random = new Random(System.nanoTime())

--- a/src/main/scala/com/init6/Init6Component.scala
+++ b/src/main/scala/com/init6/Init6Component.scala
@@ -24,6 +24,7 @@ private[init6] trait Init6Component {
   val topCommandActor = system.actorSelection(s"/user/$INIT6_TOP_COMMAND_PATH")
   val serverRegistry = system.actorSelection(s"/user/$INIT6_SERVER_REGISTRY_PATH")
   val serverAnnouncementActor = system.actorSelection(s"/user/$INIT6_SERVER_ANNOUNCEMENT_PATH")
+  val d2csActor = system.actorSelection(s"/user/$D2CS_REALMS_PATH")
 
 //  val lesserEvilAgg = system.actorSelection("/user/lesserevil")
 

--- a/src/main/scala/com/init6/channels/ChannelActor.scala
+++ b/src/main/scala/com/init6/channels/ChannelActor.scala
@@ -49,8 +49,10 @@ case class User(
   client: String = "CHAT",
 
   // Changeable
+  var realm: Option[String] = None,
   var character: Option[String] = None,
   var statstring: Option[ByteString] = None,
+  var inGame: Option[String] = None,
   inChannel: String = "",
   channelTimestamp: Long = 0
 ) extends Command
@@ -262,7 +264,6 @@ trait ChannelActor extends Init6RemotingActor {
       users
         .values
         .foreach(userActor ! UserIn(_))
-
     case c@ AddUser(actor, user, _) => add(actor, user)
     case RemUser(actor) => rem(actor)
     case CheckSize => sender() ! ChannelSize(self, name, users.size)

--- a/src/main/scala/com/init6/coders/binary/packets/SidLogonRealmEx.scala
+++ b/src/main/scala/com/init6/coders/binary/packets/SidLogonRealmEx.scala
@@ -13,7 +13,7 @@ import scala.util.Try
  */
 object SidLogonRealmEx extends BinaryPacket {
 
-  case class SidLogonRealmEx(title: String)
+  case class SidLogonRealmEx(clientToken: Int, realmPasswordHash: Array[Byte], realmName: String)
 
   override val PACKET_ID: Byte = Packets.SID_LOGONREALMEX
 
@@ -27,15 +27,19 @@ object SidLogonRealmEx extends BinaryPacket {
    * (UINT32)[12] MCP Chunk 2
    * (STRING)     Battle.net unique name (* as of D2 1.14d, this is empty)
    */
-  def apply(cookie: Int, username: String): ByteString = {
+  def apply(cookie: Int, realmName: String, username: String): ByteString = {
+    val (ip, port) = Config().Realm.realms.find(_._1 == realmName)
+      .map { case (_, ip, port) => (ip, port) }
+      .getOrElse(("127.0.0.1", 6113))
+
     build(
       ByteString.newBuilder
         .putInt(cookie) // cookie
         .putInt(0x00000000) // status
         .putInt(0x00000000) // mcp chunk 1.1
         .putInt(0x00000001) // mcp chunk 1.2
-        .putInt(aton(Config().Realm.ipAddress)) // ip
-        .putInt(htons(6113)) // port
+        .putInt(aton(ip)) // ip
+        .putInt(htons(port)) // port
         .putInt(0x67C48058) // mcp chunk 2
         .putInt(0x00000000) // magic
         .putInt(0x00000000)
@@ -54,7 +58,15 @@ object SidLogonRealmEx extends BinaryPacket {
   }
 
   def unapply(data: ByteString): Option[SidLogonRealmEx] = {
-    Some(SidLogonRealmEx("Sanctuary"))
+    //Some(SidLogonRealmEx("Sanctuary"))
+    Try {
+      val debuffer = DeBuffer(data)
+      SidLogonRealmEx(
+        debuffer.dword(), //Client Token
+        debuffer.byteArray(20), //Hashed realm pw
+        debuffer.string() //Realm title
+      )
+    }.toOption
   }
 
   def aton(ip: String): Int = {

--- a/src/main/scala/com/init6/coders/binary/packets/SidQueryRealms2.scala
+++ b/src/main/scala/com/init6/coders/binary/packets/SidQueryRealms2.scala
@@ -10,23 +10,26 @@ import scala.util.Try
  */
 object SidQueryRealms2 extends BinaryPacket {
 
-  case class SidQueryRealms2()
+  case class SidQueryRealms2(realms: List[String])
 
   override val PACKET_ID: Byte = Packets.SID_QUERYREALMS2
 
-  def apply(): ByteString = {
-    build(
-      ByteString.newBuilder
-        .putInt(0) // unknown
-        .putInt(1) // count
-        .putInt(1) // unknown
-        .putBytes("Sanctuary") // title
-        .putBytes("Diablo II on init6 in 2025") // description
-        .result()
-    )
+  def apply(realms: List[String]): ByteString = {
+
+    val bs = ByteString.newBuilder
+      .putInt(0) // unknown
+      .putInt(realms.size) // realm count
+
+    realms.foreach { name =>
+      bs.putInt(1) // unknown
+      bs.putBytes(name) // realm name
+      bs.putBytes("Diablo II on init6 in 2025") // realm description
+    }
+
+    build(bs.result())
   }
 
   def unapply(data: ByteString): Option[SidQueryRealms2] = {
-    Some(SidQueryRealms2())
+    Some(SidQueryRealms2(List.empty[String]))
   }
 }

--- a/src/main/scala/com/init6/connection/binary/BinaryMessageHandler.scala
+++ b/src/main/scala/com/init6/connection/binary/BinaryMessageHandler.scala
@@ -13,8 +13,7 @@ import com.init6.coders.binary.packets.Packets._
 import com.init6.coders.binary.packets._
 import com.init6.coders.commands.{FriendsList, PongCommand}
 import com.init6.connection._
-import com.init6.connection.d2cs.D2CSMessageHandler.userCache
-import com.init6.connection.d2cs.{D2CSGameRequest, D2CSGameResponse, D2CSMessageHandler}
+import com.init6.connection.d2cs.{GetRealmLoginInfo, GetRealms, RealmLoginInfoResponse, RealmNamesList, ReceivedGameRequest, ReceivedGameResponse}
 import com.init6.db.{CreateAccount, DAO, DAOCreatedAck, RealmCreateCookie, RealmCreateCookieAck, UpdateAccountPassword}
 import com.init6.users._
 import com.init6.utils.{HttpUtils, LimitedAction}
@@ -70,6 +69,7 @@ class BinaryMessageHandler(connectionInfo: ConnectionInfo) extends Init6KeepAliv
   var username: String = _
   var oldUsername: String = _
   var productId: String = _
+  var realmName: String = _
 
   var actor: ActorRef = ActorRef.noSender
 
@@ -81,33 +81,28 @@ class BinaryMessageHandler(connectionInfo: ConnectionInfo) extends Init6KeepAliv
       case SID_QUERYREALMS2 =>
         binaryPacket.packet match {
           case SidQueryRealms2(packet) =>
-            send(SidQueryRealms2())
+            //send(SidQueryRealms2(Config().Realm.realms))
+          d2csActor ! GetRealms(connectionInfo)
         }
       case SID_LOGONREALMEX =>
         binaryPacket.packet match {
           case SidLogonRealmEx(packet) =>
+            realmName = packet.realmName //Set realm to what the client selected
+            usersActor ! SetRealm(username, realmName)
             daoActor ! RealmCreateCookie(userId)
             return goto(ExpectingRealmCreateCookieFromDAO)
         }
       case SID_STARTADVEX3 =>
-        D2CSMessageHandler.actor match {
-          case Some(actor) =>
-            log.info("SID_STARTADVEX3 Some")
-            binaryPacket.packet match {
-              case SidStartAdvEx3(packet) =>
-//                val message = s"**${username}** created game **${packet.name}**."
-//                HttpUtils.postMessage("http://127.0.0.1:8889/d2_activity", message)
-                actor ! D2CSGameRequest(0, packet.name)
-            }
-          case None =>
-            log.info("SID_STARTADVEX3 None")
-            send(SidStartAdvEx3(SidStartAdvEx3.RESULT_UNAVAILABLE))
+        binaryPacket.packet match {
+          case SidStartAdvEx3(packet) =>
+            d2csActor ! ReceivedGameRequest(self, username, realmName, packet.name)
         }
       case SID_NOTIFYJOIN =>
         binaryPacket.packet match {
           case SidNotifyJoin(packet) =>
             val message = s"**${username}** joined game **${packet.name}**."
             HttpUtils.postMessage("http://127.0.0.1:8889/d2_activity", message)
+            usersActor ! JoinGame(username, packet.name) //Add Product later!
         }
       /* Sanctuary */
       case SID_NULL =>
@@ -188,7 +183,10 @@ class BinaryMessageHandler(connectionInfo: ConnectionInfo) extends Init6KeepAliv
 
   when(ExpectingRealmCreateCookieFromDAO) {
     case Event(RealmCreateCookieAck(cookie), _) =>
-      send(SidLogonRealmEx(cookie, oldUsername))
+      //Use config information for now!
+      //d2csActor ! GetRealmLoginInfo(connectionInfo, cookie, realmName, oldUsername)
+      log.info(s">> Sent SID_LOGONREALMEX($cookie, $username)")
+      send(SidLogonRealmEx(cookie, realmName, oldUsername))
       goto(ExpectingSidEnterChat)
   }
 
@@ -517,6 +515,13 @@ class BinaryMessageHandler(connectionInfo: ConnectionInfo) extends Init6KeepAliv
   }
 
   when(ExpectingSidEnterChat) {
+    case Event(RealmNamesList(allRealmNames), _) =>
+      send(SidQueryRealms2(allRealmNames))
+      stay()
+    case Event(RealmLoginInfoResponse(realmName, cookie, ip, port, username), _) => //Not used. Using config for realm info currently.
+      log.info(s">> Sent SID_LOGONREALMEX($cookie, $ip, $port, $username)")
+      //send(SidLogonRealmEx(cookie, ip, port, username))
+      stay()
     case Event(BinaryPacket(packetId, data), actor) =>
       log.debug(">> {} Received: {}", connectionInfo.actor, f"$packetId%X")
       packetId match {
@@ -533,10 +538,13 @@ class BinaryMessageHandler(connectionInfo: ConnectionInfo) extends Init6KeepAliv
   }
 
   when(LoggedIn) {
-    case Event(D2CSGameResponse(successful), _) =>
-      log.info(">> Received D2CSGameResponse")
-      send(SidStartAdvEx3(if (successful) 0 else 1))
-      log.info(">> Sent SID_STARTADVEX3")
+    //For now, have this in both since after it's logged in, it will stay here.
+    case Event(RealmNamesList(allRealmNames), _) =>
+      send(SidQueryRealms2(allRealmNames))
+      stay()
+    case Event(ReceivedGameResponse(result), _) =>
+      send(SidStartAdvEx3(result))
+      log.info(s">> Sent SID_STARTADVEX3(${result})")
       stay()
     case Event(BinaryPacket(packetId, data), actor) =>
       log.debug(">> {} Received: {}", connectionInfo.actor, f"$packetId%X")

--- a/src/main/scala/com/init6/connection/d2cs/D2CSActor.scala
+++ b/src/main/scala/com/init6/connection/d2cs/D2CSActor.scala
@@ -1,0 +1,175 @@
+package com.init6.connection.d2cs
+
+import akka.util.ByteString
+import akka.actor.{Actor, ActorRef, FSM, Props, Terminated}
+import com.init6.Constants.D2CS_REALMS_PATH
+import com.init6.coders.binary.packets.SidStartAdvEx3
+import com.init6.connection.ConnectionInfo
+import com.init6.{Init6Actor, Init6Component, Init6LoggingActor}
+import com.init6.d2cs.D2CS
+import com.init6.coders.d2cs.packets.{D2CSAccountLoginRequest, D2CSAuthReply, D2CSAuthRequest, D2CSCharLoginRequest, D2CSGameInfoRequest, Packets}
+import com.init6.users.SetCharacter
+
+import scala.collection.mutable
+
+//Flow order between BinaryMessageHandler, D2CSMessageHandler, and D2CSActor
+case class RegisterRealm(d2csHandler: ActorRef, connectionInfo: ConnectionInfo)
+case class D2CSRegistered(connectionInfo: ConnectionInfo, sessionNum: Int)
+case class SetRealmName(connectionInfo: ConnectionInfo, name: String)
+case class GetRealms(connectionInfo: ConnectionInfo)
+case class RealmNamesList(realmList: List[String])
+case class GetRealmLoginInfo(connectionInfo: ConnectionInfo, cookie: Int, realmName: String, oldUsername: String)
+case class RealmLoginInfoResponse(realmName: String, cookie: Int, ip: String, port: Int, username: String)
+case class AccountLoginRequest(connectionInfo: ConnectionInfo, seqNum: Int, sessionNum: Int, accountName: String)
+case class ReturnAccountLoginRequest(seqNo: Int, accountName: String, result: Int)
+case class CharLoginRequest(connectionInfo: ConnectionInfo, seqNum: Int, sessionNum: Int, characterName: String, characterPortrait: ByteString)
+case class ReturnCharLoginRequest(seqNum: Int, sessionNum: Int, accountName: String, characterName: String, RESULT_FAILURE: Int)
+case class ReceivedGameRequest(binaryActor: ActorRef, accountName:String, realmName: String, name: String)
+case class ReceivedGameResponse(successful: Int)
+case class GameInfoRequest(connectionInfo: ConnectionInfo, gameName: String)
+
+case class RemoveRealm(connectionInfo: ConnectionInfo)
+
+object D2CSActor extends Init6Component {
+  def apply() = system.actorOf(Props[D2CSActor], D2CS_REALMS_PATH)
+}
+
+class D2CSActor extends Init6Actor with Init6LoggingActor {
+  val actorPath = D2CS_REALMS_PATH
+  var sessionNum = 1
+
+  val realmConnections = mutable.Map.empty[ActorRef, D2CS]
+
+  def loggedReceive: Receive = {
+    case RegisterRealm(d2csHandler, connectionInfo) =>
+      val actorRef = connectionInfo.actor
+      val newD2CS = D2CS(
+        d2csHandler = d2csHandler,
+        sessionNum = sessionNum,
+        connectionInfo = connectionInfo,
+        binaryHandler = mutable.HashMap.empty[String, ActorRef],
+        userCache = mutable.HashMap.empty[Int, String],
+        characterCache = mutable.HashMap.empty[Int, String],
+        gameCache = mutable.HashMap.empty[String, String]
+      )
+      if (!realmConnections.contains(actorRef)) {
+        // Register the ConnectionInfo (which contains the actor and other relevant data)
+        realmConnections.put(actorRef, newD2CS)
+        //log.info(s"Registered realm connection for actor: $actorRef")
+        sender() ! D2CSRegistered(connectionInfo, newD2CS.sessionNum)
+        sessionNum += 1
+      }
+    case SetRealmName(connectionInfo, realmName) =>
+      realmConnections.get(connectionInfo.actor) match {
+        case Some(info) =>
+          log.info(s"D2CS ConnectInfo $connectionInfo set Realm name: $realmName.")
+          info.realmName = realmName
+        case None =>
+          log.error(s"D2CS SetRealmName failed! ConnectionInfo: $connectionInfo not found in realm list.")
+      }
+    case GetRealms(connectionInfo) =>
+      val allRealmNames = realmConnections.values.map(_.realmName).toList
+      sender() ! RealmNamesList(allRealmNames)
+    case GetRealmLoginInfo(connectionInfo, cookie, targetRealmName, username) => //Not used. Using config for now.
+      val maybeInfo = realmConnections.values.find(_.realmName.equalsIgnoreCase(targetRealmName))
+
+      maybeInfo match {
+        case Some(info) =>
+          val ip   = info.connectionInfo.ipAddress.getAddress.getHostAddress
+          val port = info.connectionInfo.port // Can't use this because it's connection is on 6112...
+          sender() ! RealmLoginInfoResponse(info.realmName, cookie, ip, port, username)
+
+        case None =>
+          log.warning(s"Requested realm '$targetRealmName' not found.")
+          sender() ! RealmLoginInfoResponse(targetRealmName, cookie, "127.0.0.1", 6113, username)
+      }
+    case AccountLoginRequest(connectionInfo, seqNum, sessionNum, accountName) =>
+      realmConnections.get(connectionInfo.actor) match {
+        case Some(info) =>
+          if(info.userCache.values.exists(_.toLowerCase == accountName.toLowerCase)){
+            val existingKey = info.userCache.collectFirst {
+              case (key, value) if value.toLowerCase == accountName.toLowerCase => key
+            }
+            log.info(s"D2CS AccountLoginRequest: Account Name found! Session number: $existingKey.")
+            existingKey.foreach(info.userCache -= _)
+          } else if (info.userCache.contains(sessionNum)) {
+            log.error(s"Session Number: $sessionNum already in D2CS User Cache for ${info.realmName}.")
+            info.userCache.remove(sessionNum)
+          }
+          info.userCache += sessionNum -> accountName
+          log.info(s"D2CS AccountLoginRequest: Account Name added! $accountName.")
+          sender() ! ReturnAccountLoginRequest(seqNum, accountName, D2CSAccountLoginRequest.RESULT_SUCCESS)
+        case None =>
+          sender() ! ReturnAccountLoginRequest(seqNum, accountName, D2CSAccountLoginRequest.RESULT_FAILURE)
+      }
+    case CharLoginRequest(connectionInfo, seqNum, sessionNum, characterName, characterPortrait) =>
+      realmConnections.get(connectionInfo.actor) match {
+        case Some(info) =>
+          info.userCache.get(sessionNum).foreach(u =>
+            usersActor ! SetCharacter(u, characterName, characterPortrait)
+          )
+          /*
+          Removed characterCache.
+          Not needed for now and checking for character already connected is hard to do since we don't know if one disconnects.
+          Also, if you don't join a game then the client re-logs. The server doesn't know that and if we're tracking unique character logins that creates problems.
+           */
+          val charsUsername = info.userCache.getOrElse(sessionNum, "Unknown")
+          log.info(s"D2CS CharLoginRequest: Found username: $charsUsername for character $characterName.")
+
+          // Proceed with login without checking or updating characterCache
+          sender() ! ReturnCharLoginRequest(seqNum, sessionNum, charsUsername, characterName, D2CSCharLoginRequest.RESULT_SUCCESS)
+
+        case None =>
+          log.info(s"D2CS CharLoginRequest: Realm not found! Character login for $characterName failed!")
+          sender() ! ReturnCharLoginRequest(seqNum, sessionNum, "Unknown", characterName, D2CSCharLoginRequest.RESULT_FAILURE)
+      }
+
+    case ReceivedGameRequest(binaryHandler, accountName, realmName, gameName) =>
+      log.info(s"D2CS ReceivedGameRequest: $accountName on $realmName trying to create game: $gameName")
+
+      val matchingRealm = realmConnections.values.find { info =>
+        info.realmName.toLowerCase == realmName.toLowerCase
+      }
+
+      matchingRealm match {
+        case Some(info) =>
+          info.binaryHandler.put(accountName, binaryHandler)
+          if (!info.gameCache.contains(gameName.toLowerCase)) {
+            info.gameCache.put(gameName, accountName)
+            info.d2csHandler ! GameInfoRequest(info.connectionInfo, gameName) //Might not need to do this? Client tells realm to make game.
+          }
+        case None =>
+          log.error(s"D2CS ReceivedGameRequest: Could not find realm $realmName.")
+          sender() ! ReceivedGameResponse(SidStartAdvEx3.RESULT_ALREADY_EXISTS) //Apparently BNET never responded to SID_STARTADVEX3 except for open BNET.
+      }
+
+    case GameInfoRequest(connectionInfo, gameName) =>
+      realmConnections.get(connectionInfo.actor) match {
+        case Some(info) =>
+          info.gameCache.find { case (storedGameName, _) => storedGameName.equalsIgnoreCase(gameName) } match {
+            case Some((_, accountName)) =>
+              info.binaryHandler.get(accountName) match {
+                case Some(actorRef) =>
+                  actorRef ! ReceivedGameResponse(SidStartAdvEx3.RESULT_SUCCESS)
+                case None =>
+                  log.error(s"D2CS GameInfoRequest: No binary handler actor found for account: $accountName.")
+              }
+            case None =>
+              log.error(s"D2CS GameInfoRequest: Game $gameName not found in gameCache, not sending GameInfoRequest.")
+          }
+      }
+    case RemoveRealm(connectionInfo) =>
+      if (realmConnections.contains(connectionInfo.actor)) {
+        realmConnections.remove(connectionInfo.actor)
+      }
+  }
+
+  override def preStart(): Unit = {
+    log.info(s"D2CSActor started: ${self}")
+  }
+
+  override def postStop(): Unit = {
+    log.error("D2CSActor has terminated!")
+    super.postStop()
+  }
+}

--- a/src/main/scala/com/init6/connection/d2cs/D2CSMessageHandler.scala
+++ b/src/main/scala/com/init6/connection/d2cs/D2CSMessageHandler.scala
@@ -1,9 +1,9 @@
 package com.init6.connection.d2cs
 
-import akka.actor.{ActorRef, FSM, Props}
+import akka.actor.{ActorRef, FSM, PoisonPill, Props, Terminated}
 import akka.util.ByteString
+import com.init6.Config
 import com.init6.coders.d2cs.packets.{D2CSAccountLoginRequest, D2CSAuthReply, D2CSAuthRequest, D2CSCharLoginRequest, D2CSGameInfoRequest, Packets}
-import com.init6.connection.d2cs.D2CSMessageHandler.{gameCache, userCache}
 import com.init6.connection.{ConnectionInfo, Init6KeepAliveActor, WriteOut}
 import com.init6.users.SetCharacter
 import com.init6.utils.HttpUtils
@@ -13,106 +13,115 @@ import scala.collection.mutable
 sealed trait D2CSState
 case object Always extends D2CSState
 
-sealed trait D2CSCommand
-case class D2CSGameRequest(difficulty: Byte, name: String) extends D2CSCommand
-case class D2CSGameResponse(successful: Boolean) extends D2CSCommand
-
 case class D2CSPacket(packetId: Byte, seqno: Int, packet: ByteString)
 
 object D2CSMessageHandler {
-  var actor: Option[ActorRef] = None
-  private var nextSessionNum = 1
-  private val userCache = mutable.HashMap[Int, String]()
-  private val characterCache = mutable.HashMap[Int, String]()
-  private val gameCache = mutable.HashMap[String, ActorRef]()
-
   def apply(connectionInfo: ConnectionInfo): Props = Props(classOf[D2CSMessageHandler], connectionInfo)
 }
 
 class D2CSMessageHandler(connectionInfo: ConnectionInfo) extends Init6KeepAliveActor with FSM[D2CSState, ActorRef] {
 
-  D2CSMessageHandler.actor = Some(self)
+  private val hostString = connectionInfo.ipAddress.getHostString
 
-  val selfSessionnum: Int = D2CSMessageHandler.nextSessionNum
-  D2CSMessageHandler.nextSessionNum += 1
-  send(D2CSAuthRequest(selfSessionnum))
-  log.info(">> Sent D2CS_AUTHREQ")
+  log.info(s"Created D2CS Message Handler - IP: ${hostString}")
+  d2csActor ! RegisterRealm(self, connectionInfo) //Add check to see if realm is in the config.
+  //Does D2CS go through iplimitactor? Could it get ipbanned?
 
   startWith(Always, ActorRef.noSender)
   context.watch(connectionInfo.actor)
 
   when (Always) {
-    case Event(D2CSGameRequest(difficulty, name), _) =>
-      log.info(">> Received D2CSGameRequest")
-      D2CSMessageHandler.gameCache += name -> sender()
-      send(D2CSGameInfoRequest(name))
-      log.info(">> Sent D2CS_GAMEINFOREQ")
+    case Event(D2CSRegistered(connectionInfo, sessionNum), _) =>
+      send(D2CSAuthRequest(sessionNum))
+      log.info(s"Realm Registered received from D2CSActor, connectionInfo: ${connectionInfo.actor}, sessionNum: ${sessionNum}")
+      log.info(s"[${hostString}] >> Sent D2CS_AUTHREQ")
+      stay()
+    case Event(ReturnAccountLoginRequest(seqNum, accountName, result), _) =>
+      result match {
+        case D2CSAccountLoginRequest.RESULT_SUCCESS =>
+          val realmName = Config().Realm.realms.find(_._2 == connectionInfo.ipAddress.getHostString)
+            .map { case (realmName, _, _) => realmName } //Check this?
+            .getOrElse(("Unknown"))
+          val message = s"**${accountName}** signed into **${realmName}**."
+          HttpUtils.postMessage("http://127.0.0.1:8889/d2_activity", message)
+          send(D2CSAccountLoginRequest(seqNum, D2CSAccountLoginRequest.RESULT_SUCCESS))
+          log.info(s"[${hostString}] >> Sent D2CS_ACCOUNTLOGINREQ(SUCCESS)")
+        case D2CSAccountLoginRequest.RESULT_FAILURE =>
+          send(D2CSAccountLoginRequest(seqNum, D2CSAccountLoginRequest.RESULT_FAILURE))
+          log.info(s"[${hostString}] >> Sent D2CS_ACCOUNTLOGINREQ(FAILURE)")
+      }
+      stay()
+    case Event(ReturnCharLoginRequest(seqNum, clientId, accountName, characterName, result), _) =>
+      result match {
+        case D2CSCharLoginRequest.RESULT_SUCCESS =>
+          val message = s"**${accountName}** logged onto **${characterName}**."
+          HttpUtils.postMessage("http://127.0.0.1:8889/d2_activity", message)
+          send(D2CSCharLoginRequest(seqNum, D2CSCharLoginRequest.RESULT_SUCCESS))
+        case D2CSCharLoginRequest.RESULT_FAILURE =>
+          send(D2CSCharLoginRequest(seqNum, D2CSCharLoginRequest.RESULT_FAILURE))
+      }
+      log.info(s">> Sent D2CS_CHARLOGINREQ(${result})")
+      stay()
+    case Event(GameInfoRequest(connectionInfo, gameName), _) =>
+      send(D2CSGameInfoRequest(gameName))
+      log.info(s">> Send D2CSGameInfoRequest(${gameName})")
       stay()
     case Event(D2CSPacket(id, seqno, data), _) =>
       id match {
         case Packets.D2CS_AUTHREPLY =>
           data match {
             case D2CSAuthReply(packet) =>
-              log.info(">> Received D2CS_AUTHREPLY")
+              log.info(s"[${hostString}] >> Received D2CS_AUTHREPLY")
+              d2csActor ! SetRealmName(connectionInfo, packet.realmName)
+              //realmName = packet.realmName
               send(D2CSAuthReply(seqno, D2CSAuthReply.RESULT_SUCCESS))
-              log.info(">> Sent D2CS_AUTHREPLY")
+              log.info(s"[${hostString}] >> Sent D2CS_AUTHREPLY")
           }
         case Packets.D2CS_ACCOUNTLOGINREQ =>
           data match {
             case D2CSAccountLoginRequest(packet) =>
-              log.info(">> Received D2CS_ACCOUNTLOGINREQ")
-              if (!userCache.contains(packet.sessionnum)) {
-                val message = s"**${packet.accountName}** signed into **Sanctuary**."
-                HttpUtils.postMessage("http://127.0.0.1:8889/d2_activity", message)
-              }
-              userCache += packet.sessionnum -> packet.accountName
-              send(D2CSAccountLoginRequest(seqno, D2CSAuthReply.RESULT_SUCCESS))
-              log.info(">> Sent D2CS_ACCOUNTLOGINREQ")
+              log.info(s"[${hostString}] >> Received D2CS_ACCOUNTLOGINREQ")
+              d2csActor ! AccountLoginRequest(connectionInfo, seqno, packet.sessionnum, packet.accountName)
           }
         case Packets.D2CS_CHARLOGINREQ =>
           data match {
             case D2CSCharLoginRequest(packet) =>
-              log.info(">> Received D2CS_CHARLOGINREQ")
-              userCache.get(packet.sessionnum).foreach(u => {
-                usersActor ! SetCharacter(u, packet.characterName, packet.characterPortrait)
-              })
-              D2CSMessageHandler.characterCache.get(packet.sessionnum) match {
-                case Some(character) =>
-                  if (!character.equals(packet.characterName)) {
-                    val message = s"**${userCache.getOrElse(packet.sessionnum, "UNKNOWN")}** logged onto **${packet.characterName}**."
-                    HttpUtils.postMessage("http://127.0.0.1:8889/d2_activity", message)
-                    D2CSMessageHandler.characterCache += packet.sessionnum -> packet.characterName
-                  }
-                case None =>
-                  val message = s"**${userCache.getOrElse(packet.sessionnum, "UNKNOWN")}** logged onto **${packet.characterName}**."
-                  HttpUtils.postMessage("http://127.0.0.1:8889/d2_activity", message)
-                  D2CSMessageHandler.characterCache += packet.sessionnum -> packet.characterName
-              }
-              send(D2CSCharLoginRequest(seqno, D2CSAuthReply.RESULT_SUCCESS))
-              log.info(">> Sent D2CS_CHARLOGINREQ")
+              log.info(s"[${hostString}] >> Received D2CS_CHARLOGINREQ")
+              d2csActor ! CharLoginRequest(connectionInfo, seqno, packet.sessionnum, packet.characterName, packet.characterPortrait)
           }
         case Packets.D2CS_GAMEINFOREQ =>
-          log.info("[D2CSMessageHandler] D2CS_GAMEINFOREQ")
           data match {
             case D2CSGameInfoRequest(packet) =>
-              log.info(">> Received D2CS_GAMEINFOREPLY")
-              gameCache.get(packet.gameName).foreach(a => {
-                a ! D2CSGameResponse(true)
-                log.info(">> Sent D2CSGameResponse")
-              })
+              log.info(s"[${hostString}] >> Received D2CS_GAMEINFOREQ")
+              d2csActor ! GameInfoRequest(connectionInfo, packet.gameName)
             case a =>
-              log.info(">> Unhandled {}", a.toString())
+              log.info(s"[${hostString}] >> Unhandled {}", a.toString())
           }
         case _ =>
-          log.info("[D2CSMessageHandler] Unhandled 0x{}", f"$id%X")
+          log.info(s"[${hostString}] >> Unhandled 0x{}", f"$id%X")
       }
       stay()
     case a =>
-      log.info("[D2CSMessageHandler] Unhandled {}", a.toString)
+      log.info(s"[${hostString}] >> Unhandled {}", a.toString)
       stay()
+    case Event(Terminated(deadActor), _) =>
+      log.error(s"Actor ${deadActor} was terminated unexpectedly!")
+      stop()
   }
 
   def send(data: ByteString): Unit = {
+    log.info(s"D2CSMessageHandler ${self} Writing out to actor: ${connectionInfo.actor}")
     connectionInfo.actor ! WriteOut(data)
+  }
+
+  override def preStart(): Unit = {
+    log.info(s"D2CSMessageHandler started: ${self}")
+  }
+
+  onTermination {
+    case x =>
+      log.debug(">> {} D2CSMessageHandler onTermination: {}", connectionInfo.actor, x)
+      connectionInfo.actor ! PoisonPill
+      d2csActor ! RemoveRealm(connectionInfo)
   }
 }

--- a/src/main/scala/com/init6/d2cs/D2CS.scala
+++ b/src/main/scala/com/init6/d2cs/D2CS.scala
@@ -1,0 +1,17 @@
+package com.init6.d2cs
+
+import akka.actor.ActorRef
+import com.init6.connection.ConnectionInfo
+
+import scala.collection.mutable
+
+case class D2CS(
+  var realmName: String = "Unknown",
+  d2csHandler: ActorRef,
+  connectionInfo: ConnectionInfo,
+  binaryHandler: mutable.HashMap[String, ActorRef],
+  var sessionNum: Int = 1,
+  userCache: mutable.HashMap[Int, String],
+  characterCache: mutable.HashMap[Int, String],
+  gameCache: mutable.HashMap[String, String]
+)

--- a/src/main/scala/com/init6/users/UserActor.scala
+++ b/src/main/scala/com/init6/users/UserActor.scala
@@ -90,13 +90,20 @@ class UserActor(connectionInfo: ConnectionInfo, var user: User, var encoder: Enc
       user.character = Some(character)
       val fullStatstring = {
         user.client.getBytes() ++
-        "Sanctuary".getBytes() ++
+        user.realm.getOrElse("Unknown").getBytes() ++
         Array(0x2C.toByte) ++
         character.getBytes() ++
         Array(0x2C.toByte) ++
         statstring
       }
       user.statstring = Some(ByteString(fullStatstring))
+
+    case SetRealm(username, realm) =>
+      user.realm = Some(realm)
+
+    case JoinGame(username, game) =>
+      user.inGame = Some(game)
+      if (user.inChannel != "") channelActor ! RemUser(self)
 
     case JoinChannelFromConnection(channel, forceJoin) =>
       log.debug("matched JoinChannelFromConnection")
@@ -572,7 +579,7 @@ class UserActor(connectionInfo: ConnectionInfo, var user: User, var encoder: Enc
     }
     if (Flags.isAdmin(user) ||
       !Config().Server.Chat.enabled ||
-      Config().Server.Chat.channels.contains(sanitizedChannel.toLowerCase)
+      Config().Server.Chat.channels.map(_.toLowerCase).contains(sanitizedChannel.toLowerCase)
     ) {
       implicit val timeout = Timeout(2, TimeUnit.SECONDS)
       //println(user.name + " - " + self + " - SENDING JOIN")

--- a/src/main/scala/com/init6/users/UsersActor.scala
+++ b/src/main/scala/com/init6/users/UsersActor.scala
@@ -27,6 +27,8 @@ case class RemoteAdd(userActor: ActorRef, username: String) extends Command
 case class Rem(ipAddress: InetSocketAddress, userActor: ActorRef) extends Command with Remotable
 case class RemActors(userActors: Set[ActorRef]) extends Command
 case class SetCharacter(username: String, character: String, statstring: ByteString) extends Command
+case class SetRealm(username: String, realm: String) extends Command
+case class JoinGame(username: String, game: String)
 
 case class WhisperTo(user: User, username: String, message: String)  extends Command
 case object SubscribeAll
@@ -277,6 +279,18 @@ class UsersActor extends Init6RemotingActor with Init6LoggingActor {
       val user = users.get(username)
       user.foreach(u => {
         u._2 ! SetCharacter(username, character, statstring)
+      })
+
+    case SetRealm(username, realm) =>
+      val user = users.get(username)
+      user.foreach(u => {
+        u._2 ! SetRealm(username, realm)
+      })
+
+    case JoinGame(username, game) =>
+      val user = users.get(username)
+      user.foreach(u => {
+        u._2 ! JoinGame(username, game)
       })
 
     case Rem(ipAddress, userActor) =>


### PR DESCRIPTION
# Added Diablo 2 multi-realm support.
![D2 realm - SANC](https://github.com/user-attachments/assets/32305045-500b-4cf4-a482-0789a72bad5d)
![d2 realm - test](https://github.com/user-attachments/assets/dd6acced-21a0-48ff-a258-7b2fabb7fa00)

Fixed response to SID_NOTIFYJOIN - Users now leave channel when joining a game. 
Fixed chat server only channels - Previously case-sensitive; now any channel listed in config is properly compared.